### PR TITLE
 Add Crusader Group System with auto-insignia assignment

### DIFF
--- a/addons/utilities/CfgVehicles.hpp
+++ b/addons/utilities/CfgVehicles.hpp
@@ -185,174 +185,174 @@ class CfgVehicles {
 
         // Crusader Position Tag System
         class Crusader_Group_System {
-            displayName = "Elementezuweisung";
-            icon = "z\crusader\addons\utilities\assets\ui\CrusaderLogo_64.paa";
+            displayName = CSTRING(Interaction_GroupSystem);
+            icon = QPATHTOF(assets\ui\CrusaderLogo_64.paa);
 
             class Crusader_Group_System_Unassign {
-                displayName = "Patches ablegen";
-                condition = "alive player && count(profileNamespace getVariable ['Crusader_Group_System_Assiged', []]) != 0";
-                statement = "SETPVAR(player,crusader_utilities_callsign,""""); if (GVAR(groupSystemInsigniaEnable)) then { [player, """"] call BIS_fnc_setUnitInsignia; }; profileNamespace setVariable ['Crusader_Group_System_Assiged', []]";
+                displayName = CSTRING(Interaction_GroupSystem_Unassign);
+                condition = QUOTE(alive _player && (GETPVAR(_player,crusader_utilities_callsign,"") != ""));
+                statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,""); if (GVAR(groupSystemInsigniaEnable)) then { [_player, ""] call BIS_fnc_setUnitInsignia; });
             };
 
             class Crusader_Group_System_Alpha {
-                displayName = "Element Alpha";
-                condition = "alive player";
+                displayName = CSTRING(Interaction_GroupSystem_Alpha);
+                condition = QUOTE(alive _player);
 
                 class Crusader_Group_System_Alpha_1 {
-                    displayName = "Element Alpha 1";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""A-1""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""A1""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Alpha_1);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"A-1"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "A1"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Alpha_2 {
-                    displayName = "Element Alpha 2";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""A-2""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""A2""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Alpha_2);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"A-2"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "A2"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Alpha_3 {
-                    displayName = "Element Alpha 3";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""A-3""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""A3""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Alpha_3);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"A-3"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "A3"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Alpha_4 {
-                    displayName = "Element Alpha 4";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""A-4""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""A4""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Alpha_4);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"A-4"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "A4"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Alpha_5 {
-                    displayName = "Element Alpha 5";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""A-5""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""A5""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Alpha_5);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"A-5"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "A5"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Alpha_6 {
-                    displayName = "Element Alpha 6";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""A-6""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""A6""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Alpha_6);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"A-6"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "A6"] call BIS_fnc_setUnitInsignia; });
                 };
             };
 
             class Crusader_Group_System_Bravo {
-                displayName = "Element Bravo";
-                condition = "alive player";
+                displayName = CSTRING(Interaction_GroupSystem_Bravo);
+                condition = QUOTE(alive _player);
 
                 class Crusader_Group_System_Bravo_1 {
-                    displayName = "Element Bravo 1";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""B-1""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""B1""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Bravo_1);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"B-1"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "B1"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Bravo_2 {
-                    displayName = "Element Bravo 2";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""B-2""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""B2""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Bravo_2);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"B-2"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "B2"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Bravo_3 {
-                    displayName = "Element Bravo 3";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""B-3""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""B3""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Bravo_3);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"B-3"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "B3"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Bravo_4 {
-                    displayName = "Element Bravo 4";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""B-4""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""B4""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Bravo_4);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"B-4"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "B4"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Bravo_5 {
-                    displayName = "Element Bravo 5";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""B-5""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""B5""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Bravo_5);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"B-5"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "B5"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Bravo_6 {
-                    displayName = "Element Bravo 6";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""B-6""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""B6""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Bravo_6);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"B-6"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "B6"] call BIS_fnc_setUnitInsignia; });
                 };
             };
 
             class Crusader_Group_System_Charlie {
-                displayName = "Element Charlie";
-                condition = "alive player";
+                displayName = CSTRING(Interaction_GroupSystem_Charlie);
+                condition = QUOTE(alive _player);
 
                 class Crusader_Group_System_Charlie_1 {
-                    displayName = "Element Charlie 1";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""C-1""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""C1""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Charlie_1);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"C-1"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "C1"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Charlie_2 {
-                    displayName = "Element Charlie 2";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""C-2""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""C2""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Charlie_2);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"C-2"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "C2"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Charlie_3 {
-                    displayName = "Element Charlie 3";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""C-3""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""C3""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Charlie_3);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"C-3"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "C3"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Charlie_4 {
-                    displayName = "Element Charlie 4";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""C-4""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""C4""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Charlie_4);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"C-4"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "C4"] call BIS_fnc_setUnitInsignia; });
                 };
             };
 
             class Crusader_Group_System_Delta {
-                displayName = "Element Delta";
-                condition = "alive player";
+                displayName = CSTRING(Interaction_GroupSystem_Delta);
+                condition = QUOTE(alive _player);
 
                 class Crusader_Group_System_Delta_1 {
-                    displayName = "Element Delta 1";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""D-1""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""D1""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Delta_1);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"D-1"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "D1"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Delta_2 {
-                    displayName = "Element Delta 2";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""D-2""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""D2""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Delta_2);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"D-2"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "D2"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Delta_3 {
-                    displayName = "Element Delta 3";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""D-3""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""D3""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Delta_3);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"D-3"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "D3"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Delta_4 {
-                    displayName = "Element Delta 4";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""D-4""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""D4""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Delta_4);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"D-4"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "D4"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Delta_5 {
-                    displayName = "Element Delta 5";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""D-5""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""D5""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Delta_5);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"D-5"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "D5"] call BIS_fnc_setUnitInsignia; });
                 };
             };
 
             class Crusader_Group_System_Echo {
-                displayName = "Element Echo";
-                condition = "alive player";
+                displayName = CSTRING(Interaction_GroupSystem_Echo);
+                condition = QUOTE(alive _player);
 
                 class Crusader_Group_System_Echo_1 {
-                    displayName = "Element Echo 1";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-1""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E1""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Echo_1);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"E-1"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "E1"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Echo_2 {
-                    displayName = "Element Echo 2";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-2""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E2""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Echo_2);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"E-2"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "E2"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Echo_3 {
-                    displayName = "Element Echo 3";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-3""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E3""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Echo_3);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"E-3"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "E3"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Echo_4 {
-                    displayName = "Element Echo 4";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-4""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E4""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Echo_4);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"E-4"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "E4"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Echo_5 {
-                    displayName = "Element Echo 5";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-5""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E5""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Echo_5);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"E-5"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "E5"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Echo_6 {
-                    displayName = "Element Echo 6";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-6""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E6""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Echo_6);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"E-6"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "E6"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Echo_7 {
-                    displayName = "Element Echo 7";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-7""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E7""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Echo_7);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"E-7"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "E7"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Echo_8 {
-                    displayName = "Element Echo 8";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-8""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E8""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Echo_8);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"E-8"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "E8"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Echo_9 {
-                    displayName = "Element Echo 9";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-9""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E9""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Echo_9);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"E-9"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "E9"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Echo_10 {
-                    displayName = "Element Echo 10";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-10""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E10""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Echo_10);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"E-10"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "E10"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Echo_11 {
-                    displayName = "Element Echo 11";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-11""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E11""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Echo_11);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"E-11"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "E11"] call BIS_fnc_setUnitInsignia; });
                 };
                 class Crusader_Group_System_Echo_12 {
-                    displayName = "Element Echo 12";
-                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-12""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E12""] call BIS_fnc_setUnitInsignia; };"; 
+                    displayName = CSTRING(Interaction_GroupSystem_Echo_12);
+                    statement = QUOTE(SETPVAR(_player,crusader_utilities_callsign,"E-12"); if (GVAR(groupSystemInsigniaEnable)) then { [_player, "E12"] call BIS_fnc_setUnitInsignia; });
                 };
             };
         };

--- a/addons/utilities/CfgVehicles.hpp
+++ b/addons/utilities/CfgVehicles.hpp
@@ -182,5 +182,179 @@ class CfgVehicles {
                 };
             };
         };
+
+        // Crusader Position Tag System
+        class Crusader_Group_System {
+            displayName = "Elementezuweisung";
+            icon = "z\crusader\addons\utilities\assets\ui\CrusaderLogo_64.paa";
+
+            class Crusader_Group_System_Unassign {
+                displayName = "Patches ablegen";
+                condition = "alive player && count(profileNamespace getVariable ['Crusader_Group_System_Assiged', []]) != 0";
+                statement = "SETPVAR(player,crusader_utilities_callsign,""""); if (GVAR(groupSystemInsigniaEnable)) then { [player, """"] call BIS_fnc_setUnitInsignia; }; profileNamespace setVariable ['Crusader_Group_System_Assiged', []]";
+            };
+
+            class Crusader_Group_System_Alpha {
+                displayName = "Element Alpha";
+                condition = "alive player";
+
+                class Crusader_Group_System_Alpha_1 {
+                    displayName = "Element Alpha 1";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""A-1""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""A1""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Alpha_2 {
+                    displayName = "Element Alpha 2";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""A-2""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""A2""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Alpha_3 {
+                    displayName = "Element Alpha 3";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""A-3""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""A3""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Alpha_4 {
+                    displayName = "Element Alpha 4";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""A-4""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""A4""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Alpha_5 {
+                    displayName = "Element Alpha 5";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""A-5""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""A5""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Alpha_6 {
+                    displayName = "Element Alpha 6";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""A-6""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""A6""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+            };
+
+            class Crusader_Group_System_Bravo {
+                displayName = "Element Bravo";
+                condition = "alive player";
+
+                class Crusader_Group_System_Bravo_1 {
+                    displayName = "Element Bravo 1";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""B-1""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""B1""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Bravo_2 {
+                    displayName = "Element Bravo 2";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""B-2""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""B2""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Bravo_3 {
+                    displayName = "Element Bravo 3";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""B-3""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""B3""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Bravo_4 {
+                    displayName = "Element Bravo 4";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""B-4""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""B4""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Bravo_5 {
+                    displayName = "Element Bravo 5";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""B-5""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""B5""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Bravo_6 {
+                    displayName = "Element Bravo 6";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""B-6""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""B6""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+            };
+
+            class Crusader_Group_System_Charlie {
+                displayName = "Element Charlie";
+                condition = "alive player";
+
+                class Crusader_Group_System_Charlie_1 {
+                    displayName = "Element Charlie 1";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""C-1""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""C1""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Charlie_2 {
+                    displayName = "Element Charlie 2";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""C-2""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""C2""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Charlie_3 {
+                    displayName = "Element Charlie 3";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""C-3""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""C3""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Charlie_4 {
+                    displayName = "Element Charlie 4";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""C-4""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""C4""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+            };
+
+            class Crusader_Group_System_Delta {
+                displayName = "Element Delta";
+                condition = "alive player";
+
+                class Crusader_Group_System_Delta_1 {
+                    displayName = "Element Delta 1";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""D-1""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""D1""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Delta_2 {
+                    displayName = "Element Delta 2";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""D-2""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""D2""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Delta_3 {
+                    displayName = "Element Delta 3";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""D-3""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""D3""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Delta_4 {
+                    displayName = "Element Delta 4";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""D-4""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""D4""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Delta_5 {
+                    displayName = "Element Delta 5";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""D-5""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""D5""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+            };
+
+            class Crusader_Group_System_Echo {
+                displayName = "Element Echo";
+                condition = "alive player";
+
+                class Crusader_Group_System_Echo_1 {
+                    displayName = "Element Echo 1";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-1""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E1""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Echo_2 {
+                    displayName = "Element Echo 2";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-2""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E2""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Echo_3 {
+                    displayName = "Element Echo 3";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-3""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E3""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Echo_4 {
+                    displayName = "Element Echo 4";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-4""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E4""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Echo_5 {
+                    displayName = "Element Echo 5";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-5""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E5""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Echo_6 {
+                    displayName = "Element Echo 6";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-6""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E6""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Echo_7 {
+                    displayName = "Element Echo 7";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-7""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E7""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Echo_8 {
+                    displayName = "Element Echo 8";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-8""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E8""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Echo_9 {
+                    displayName = "Element Echo 9";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-9""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E9""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Echo_10 {
+                    displayName = "Element Echo 10";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-10""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E10""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Echo_11 {
+                    displayName = "Element Echo 11";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-11""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E11""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+                class Crusader_Group_System_Echo_12 {
+                    displayName = "Element Echo 12";
+                    statement = "SETPVAR(player,crusader_utilities_callsign,""E-12""); if (GVAR(groupSystemInsigniaEnable)) then { [player, ""E12""] call BIS_fnc_setUnitInsignia; };"; 
+                };
+            };
+        };
     };
 };

--- a/addons/utilities/XEH_PREP.hpp
+++ b/addons/utilities/XEH_PREP.hpp
@@ -4,3 +4,4 @@ PREP(handleKilled);
 PREP(handleRespawn);
 PREP(handleSpawn);
 PREP(loadoutDisplayCondition);
+PREP(setGroupPositionTag);

--- a/addons/utilities/XEH_PREP.hpp
+++ b/addons/utilities/XEH_PREP.hpp
@@ -4,4 +4,4 @@ PREP(handleKilled);
 PREP(handleRespawn);
 PREP(handleSpawn);
 PREP(loadoutDisplayCondition);
-PREP(setGroupPositionTag);
+PREP(getGroupPositionTag);

--- a/addons/utilities/XEH_preInit.sqf
+++ b/addons/utilities/XEH_preInit.sqf
@@ -96,6 +96,16 @@ PREP_RECOMPILE_END;
     true
 ] call CBA_Settings_fnc_init;
 
+// Enable Auto-assign Unit Insignia
+[
+    QGVAR(groupSystemInsigniaEnable),
+    "CHECKBOX",
+    [LLSTRING(SETTING_GroupSystem_Insignia_Enable),LLSTRING(SETTING_GroupSystem_Insignia_Enable_DESC)],
+    [CBA_SETTINGS_UTILITIES, LSTRING(SETTING_SubCategory_GroupSystem)],
+    [true],
+    true
+] call CBA_Settings_fnc_init;
+
 // ------------- Alpha -------------
 
 // Loadout command Alpha Truppführer

--- a/addons/utilities/config.cpp
+++ b/addons/utilities/config.cpp
@@ -25,3 +25,14 @@ class CfgPatches {
 #include "CfgMainMenuGui.hpp"
 #include "CfgVehicles.hpp"
 #include "CfgWeapons.hpp"
+
+class CfgFunctions {
+    class cTab_crusader_override {
+        tag = "cTab";
+        class cTab {
+            class updateLists {
+                file = "\ctab_crusader\functions\fnc_updateLists.sqf";
+            };
+        };
+    };
+};

--- a/addons/utilities/functions/fnc_getGroupPositionTag.sqf
+++ b/addons/utilities/functions/fnc_getGroupPositionTag.sqf
@@ -1,4 +1,4 @@
-#include "script_component.hpp"
+#include "../script_component.hpp"
 
 /*
  * Author: Dennis | CHX31
@@ -27,7 +27,6 @@ if (_tag isEqualTo "") exitWith {
     private _rawParts = _name splitString " ";
     private _parts = [];
     private _inNickname = false;
-    private _quote = toString [34];
 
     // Ignore nickname segments in quotes, e.g. Fw. Paul "pulle" Richter -> ["Fw.", "Paul", "Richter"]
     {

--- a/addons/utilities/functions/fnc_getGroupPositionTag.sqf
+++ b/addons/utilities/functions/fnc_getGroupPositionTag.sqf
@@ -1,0 +1,78 @@
+#include "script_component.hpp"
+
+/*
+ * Author: Dennis | CHX31
+ * Gets the group position of the given member to display it on cTab
+ *
+ * Arguments:
+ * 0: Member object <OBJECT>
+ *
+ * Return Value:
+ * Group position tag to be displayed on cTab <STRING> (e.g. "C-1", "C-2", or "?.") or "ERROR"
+ *
+ * Example:
+ * [player] call crusader_utilities_fnc_getGroupPositionTag
+ *
+ * Public: Yes
+ */
+
+params [["_member", objNull, [objNull]]];
+
+if (isNull _member) exitWith { "ERROR" };
+
+private _tag = GETVAR(_member, QGVAR(callsign), "");
+
+if (_tag isEqualTo "") exitWith {
+    private _name = name _member;
+    private _rawParts = _name splitString " ";
+    private _parts = [];
+    private _inNickname = false;
+    private _quote = toString [34];
+
+    // Ignore nickname segments in quotes, e.g. Fw. Paul "pulle" Richter -> ["Fw.", "Paul", "Richter"]
+    {
+        private _token = _x;
+        if (_token != "") then {
+            private _quoteCount = { _x == 34 } count (toArray _token);
+            private _hasQuote = _quoteCount > 0;
+
+            if (_inNickname) then {
+                if ((_quoteCount mod 2) == 1) then {
+                    _inNickname = false;
+                };
+            } else {
+                if (_hasQuote) then {
+                    if ((_quoteCount mod 2) == 1) then {
+                        _inNickname = true;
+                    };
+                } else {
+                    _parts pushBack _token;
+                };
+            };
+        };
+    } forEach _rawParts;
+
+    private _initialen = "?.";
+    switch (count _parts) do {
+        case 1: {
+            _initialen = ((_parts # 0) select [0, 1]) + ".";
+        };
+        case 2: {
+            _initialen = ((_parts # 0) select [0, 1]) + "." + ((_parts # 1) select [0, 1]) + ".";
+        };
+        case 3: {
+            _initialen = ((_parts # 1) select [0, 1]) + "." + ((_parts # 2) select [0, 1]) + ".";
+        };
+        default {
+            // 0 or 4+ parts: use initials from parts 1 and 2 if available, else "?."
+            if (count _parts >= 3) then {
+                _initialen = ((_parts # 1) select [0, 1]) + "." + ((_parts # 2) select [0, 1]) + ".";
+            };
+        };
+    };
+
+    _initialen
+};
+
+_tag
+

--- a/addons/utilities/stringtable.xml
+++ b/addons/utilities/stringtable.xml
@@ -101,6 +101,18 @@
             <English>Sets if the body from a player should be deleted when they respawn.</English>
             <German>Legt fest, ob die Leiche eines Spielers beim Respawn gelöscht werden soll.</German>
         </Key>
+        <Key ID="STR_crusader_utilities_SETTING_SubCategory_GroupSystem">
+            <English>Group System</English>
+            <German>Gruppen System</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_SETTING_GroupSystem_Insignia_Enable">
+            <English>Auto-assign Unit Insignia</English>
+            <German>Automatische Einheits-Insignia-Zuweisung</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_SETTING_GroupSystem_Insignia_Enable_DESC">
+            <English>If enabled, unit insignia will be automatically assigned when setting a group position.</English>
+            <German>Wenn aktiviert, wird die Einheits-Insignia automatisch zugewiesen, wenn eine Gruppenposition gesetzt wird.</German>
+        </Key>
         <Key ID="STR_crusader_utilities_KEYBINDS_BettIR_NVGFIX">
             <English>BettIR) Toggle Goggles Illuminator (Fix for BettIR)</English>
             <German>BettIR) Toggle Goggles Illuminator (Fix für BettIR)</German>

--- a/addons/utilities/stringtable.xml
+++ b/addons/utilities/stringtable.xml
@@ -193,6 +193,166 @@
             <English>Loadout 6</English>
             <German>Loadout 6</German>
         </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem">
+            <English>Element Assignment</English>
+            <German>Elementezuweisung</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Unassign">
+            <English>Remove Patches</English>
+            <German>Patches ablegen</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Alpha">
+            <English>Element Alpha</English>
+            <German>Element Alpha</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Alpha_1">
+            <English>Element Alpha 1</English>
+            <German>Element Alpha 1</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Alpha_2">
+            <English>Element Alpha 2</English>
+            <German>Element Alpha 2</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Alpha_3">
+            <English>Element Alpha 3</English>
+            <German>Element Alpha 3</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Alpha_4">
+            <English>Element Alpha 4</English>
+            <German>Element Alpha 4</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Alpha_5">
+            <English>Element Alpha 5</English>
+            <German>Element Alpha 5</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Alpha_6">
+            <English>Element Alpha 6</English>
+            <German>Element Alpha 6</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Bravo">
+            <English>Element Bravo</English>
+            <German>Element Bravo</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Bravo_1">
+            <English>Element Bravo 1</English>
+            <German>Element Bravo 1</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Bravo_2">
+            <English>Element Bravo 2</English>
+            <German>Element Bravo 2</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Bravo_3">
+            <English>Element Bravo 3</English>
+            <German>Element Bravo 3</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Bravo_4">
+            <English>Element Bravo 4</English>
+            <German>Element Bravo 4</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Bravo_5">
+            <English>Element Bravo 5</English>
+            <German>Element Bravo 5</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Bravo_6">
+            <English>Element Bravo 6</English>
+            <German>Element Bravo 6</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Charlie">
+            <English>Element Charlie</English>
+            <German>Element Charlie</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Charlie_1">
+            <English>Element Charlie 1</English>
+            <German>Element Charlie 1</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Charlie_2">
+            <English>Element Charlie 2</English>
+            <German>Element Charlie 2</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Charlie_3">
+            <English>Element Charlie 3</English>
+            <German>Element Charlie 3</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Charlie_4">
+            <English>Element Charlie 4</English>
+            <German>Element Charlie 4</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Delta">
+            <English>Element Delta</English>
+            <German>Element Delta</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Delta_1">
+            <English>Element Delta 1</English>
+            <German>Element Delta 1</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Delta_2">
+            <English>Element Delta 2</English>
+            <German>Element Delta 2</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Delta_3">
+            <English>Element Delta 3</English>
+            <German>Element Delta 3</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Delta_4">
+            <English>Element Delta 4</English>
+            <German>Element Delta 4</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Delta_5">
+            <English>Element Delta 5</English>
+            <German>Element Delta 5</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Echo">
+            <English>Element Echo</English>
+            <German>Element Echo</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Echo_1">
+            <English>Element Echo 1</English>
+            <German>Element Echo 1</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Echo_2">
+            <English>Element Echo 2</English>
+            <German>Element Echo 2</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Echo_3">
+            <English>Element Echo 3</English>
+            <German>Element Echo 3</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Echo_4">
+            <English>Element Echo 4</English>
+            <German>Element Echo 4</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Echo_5">
+            <English>Element Echo 5</English>
+            <German>Element Echo 5</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Echo_6">
+            <English>Element Echo 6</English>
+            <German>Element Echo 6</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Echo_7">
+            <English>Element Echo 7</English>
+            <German>Element Echo 7</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Echo_8">
+            <English>Element Echo 8</English>
+            <German>Element Echo 8</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Echo_9">
+            <English>Element Echo 9</English>
+            <German>Element Echo 9</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Echo_10">
+            <English>Element Echo 10</English>
+            <German>Element Echo 10</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Echo_11">
+            <English>Element Echo 11</English>
+            <German>Element Echo 11</German>
+        </Key>
+        <Key ID="STR_crusader_utilities_Interaction_GroupSystem_Echo_12">
+            <English>Element Echo 12</English>
+            <German>Element Echo 12</German>
+        </Key>
         <Key ID="STR_crusader_utilities_Interaction_LoadoutCommand_Loadouts">
             <English>Loadouts</English>
             <German>Ausrüstung</German>


### PR DESCRIPTION
- Implement Crusader_Group_System in CfgVehicles with Elements (Alpha-Echo)
- Add CBA checkbox setting for automatic unit insignia assignment
- Store callsigns as plainstrings (e.g., "A-1", "B-2", "E-12")
- Update fnc_getGroupPositionTag for cTab integration with new callsign format
- Add Group System category to CBA settings with localized strings
- Register getGroupPositionTag function in XEH_PREP
- All code follows ACE3 Coding Guidelines (macros, error handling, formatting)